### PR TITLE
Add participant comments for recurring event responses

### DIFF
--- a/app/api/events/[eventId]/participants/[participantId]/route.ts
+++ b/app/api/events/[eventId]/participants/[participantId]/route.ts
@@ -7,7 +7,7 @@ export async function PUT(
   { params }: { params: { eventId: string; participantId: string } }
 ) {
   const { eventId, participantId } = await params
-  const { name, grade, gradePriority, schedule } = await req.json()
+  const { name, grade, gradePriority, schedule, comment: rawComment } = await req.json()
 
   if (!name || typeof name !== 'string') {
     return NextResponse.json({ error: '名前が必要です' }, { status: 400 })
@@ -22,6 +22,17 @@ export async function PUT(
     return NextResponse.json({ error: 'スケジュールが必要です' }, { status: 400 })
   }
 
+  let comment = ''
+  if (rawComment != null) {
+    if (typeof rawComment !== 'string') {
+      return NextResponse.json({ error: 'コメントは文字列で指定してください' }, { status: 400 })
+    }
+    const trimmed = rawComment.trim()
+    if (trimmed !== '') {
+      comment = trimmed
+    }
+  }
+
   try {
     await db
       .collection('events')
@@ -32,6 +43,7 @@ export async function PUT(
         name,
         grade,
         schedule,
+        comment,
         updatedAt: FieldValue.serverTimestamp(),
       })
 

--- a/app/api/events/[eventId]/participants/route.ts
+++ b/app/api/events/[eventId]/participants/route.ts
@@ -17,7 +17,7 @@ export async function GET(req: NextRequest, { params }: { params: { eventId: str
 
 export async function POST(req: NextRequest) {
   const body = await req.json()
-  const { eventId, name, grade, gradePriority, schedule } = body
+  const { eventId, name, grade, gradePriority, schedule, comment: rawComment } = body
 
   if (!eventId || typeof eventId !== "string") {
     return NextResponse.json({ error: "eventId が必要です" }, { status: 400 })
@@ -35,6 +35,17 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "スケジュールが必要です" }, { status: 400 })
   }
 
+  let comment = ""
+  if (rawComment != null) {
+    if (typeof rawComment !== "string") {
+      return NextResponse.json({ error: "コメントは文字列で指定してください" }, { status: 400 })
+    }
+    const trimmed = rawComment.trim()
+    if (trimmed !== "") {
+      comment = trimmed
+    }
+  }
+
   try {
     // ────────────── ここを修正 ──────────────
     // トップレベルの 'events' コレクション内の eventId ドキュメントを取得して、
@@ -49,6 +60,7 @@ export async function POST(req: NextRequest) {
       name,
       grade,
       schedule,
+      comment,
       createdAt: FieldValue.serverTimestamp(),
     })
 

--- a/app/en/events/[eventId]/components/constants.ts
+++ b/app/en/events/[eventId]/components/constants.ts
@@ -9,10 +9,10 @@ export type Response = {
   id: string
   name: string
   grade?: string
+  comment?: string
   schedule: {
     dateTime: string
     typeId: string
-    comment?: string
   }[]
 }
 

--- a/app/events/[eventId]/EventPage.tsx
+++ b/app/events/[eventId]/EventPage.tsx
@@ -89,6 +89,7 @@ export default function EventPage() {
               id: p.id,
               name: p.name,
               grade: p.grade,
+              comment: typeof p?.comment === "string" ? p.comment.trim() : "",
               schedule: p.schedule,
             }))
           : [],

--- a/app/events/[eventId]/components/OneTimePage.tsx
+++ b/app/events/[eventId]/components/OneTimePage.tsx
@@ -3,8 +3,18 @@
 import { useState, useEffect } from "react"
 import { useParticipantForm } from "./useParticipantForm"
 import {
-  Check, Save, User, MessageSquare, X, GraduationCap, BarChart3,
-  Users, PenSquare, Edit, Trash2, AlertTriangle,
+  Check,
+  Save,
+  User,
+  MessageSquare,
+  X,
+  GraduationCap,
+  BarChart3,
+  Users,
+  PenSquare,
+  Edit,
+  Trash2,
+  AlertTriangle,
 } from "lucide-react"
 import type { ScheduleType, Response } from "./constants"
 import { Button } from "@/components/ui/button"
@@ -189,6 +199,20 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
                     </SelectContent>
                   </Select>
                 </div>
+                <div className="md:col-span-2">
+                  <Label htmlFor="edit-comment" className="text-sm font-medium mb-1 block">
+                    <MessageSquare className="h-4 w-4 inline-block mr-1" />
+                    コメント（任意）
+                  </Label>
+                  <Textarea
+                    id="edit-comment"
+                    value={form.editComment}
+                    onChange={(e) => form.setEditComment(e.target.value)}
+                    placeholder="補足があれば入力してください（任意）"
+                    className="w-full"
+                    rows={3}
+                  />
+                </div>
               </div>
 
               {/* 日時選択セクション */}
@@ -224,25 +248,7 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
                                   {selectedTypeId === type.id && <Check className="inline-block ml-1 h-3 w-3" />}
                                 </button>
                               ))}
-                              <button
-                                onClick={() => form.toggleEditComment(dateTime)}
-                                className="text-xs text-gray-500 flex items-center hover:text-gray-700 ml-1"
-                                type="button"
-                              >
-                                <MessageSquare className="h-3 w-3 mr-1" />
-                                {form.showEditComments[dateTime] ? "閉じる" : "コメント"}
-                              </button>
                             </div>
-                            {form.showEditComments[dateTime] && (
-                              <div className="mt-2">
-                                <Textarea
-                                  placeholder="コメントを入力"
-                                  value={form.editComments[dateTime] || ""}
-                                  onChange={(e) => form.handleEditCommentChange(dateTime, e.target.value)}
-                                  className="w-full h-16 text-sm"
-                                />
-                              </div>
-                            )}
                           </td>
                         </tr>
                       )

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -12,13 +12,14 @@ import {
 import type { ScheduleType, Response } from "./constants"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Card, CardContent  } from "@/components/ui/card"
+import { Card, CardContent } from "@/components/ui/card"
 import { TabsContent } from "@/components/ui/tabs"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Checkbox } from "@/components/ui/checkbox"
 import { useParticipantForm } from "./useParticipantForm"
+import { cn } from "@/lib/utils"
 type ParticipantFormHook = ReturnType<typeof useParticipantForm>
 
 type Props = {
@@ -286,9 +287,14 @@ export default function OneTimeResponsesTab({
                       {sorted.map((r) => (
                         <td
                           key={`${dt}-${r.id}`}
-                          className={`py-0.5 px-1 text-center w-[8rem] min-w-[8rem] max-w-[8rem] ${getResponseCellClass(r, dt)}`}
+                          className={cn(
+                            "p-0 text-center align-middle w-[8rem] min-w-[8rem] max-w-[8rem]",
+                            getResponseCellClass(r, dt)
+                          )}
                         >
-                          {getResponseIcon(r, dt) || <Circle className="h-3 w-3 text-gray-200" />}
+                          <div className="flex h-10 w-full items-center justify-center">
+                            {getResponseIcon(r, dt) || <Circle className="h-3 w-3 text-gray-200" />}
+                          </div>
                         </td>
                       ))}
                     </tr>
@@ -300,14 +306,16 @@ export default function OneTimeResponsesTab({
                     {sorted.map((r) => (
                       <td
                         key={`comment-${r.id}`}
-                        className="py-0.5 px-1 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
+                        className="p-0 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
                       >
                         {r.comment && r.comment.trim() !== "" ? (
-                          <div className="text-[10px] text-gray-500 whitespace-pre-wrap break-words leading-tight">
+                          <div className="whitespace-pre-wrap break-words px-2 py-1 text-[10px] text-gray-500 leading-tight">
                             {r.comment}
                           </div>
                         ) : (
-                          <span className="text-[10px] text-gray-300">-</span>
+                          <div className="flex h-10 items-center justify-center text-[10px] text-gray-300">
+                            -
+                          </div>
                         )}
                       </td>
                     ))}

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -238,90 +238,92 @@ export default function OneTimeResponsesTab({
           {/* テーブル, sortedに回答されたデータがある */}
           {sorted.length > 0 ? (
             <div className="border rounded-md overflow-auto max-h-96">
-              <table className="w-full border-collapse text-xs">
-                <thead className="sticky top-0 z-10 bg-white">
-                  <tr className="bg-gray-50 border-b">
-                    <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
-                      日時
-                    </th>
-                    {sorted.map((r) => (
-                      <th
-                        key={r.id}
-                        className="py-0.5 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[8rem] min-w-[8rem] max-w-[8rem]"
-                        onClick={() => form.openEditDialog(r)}
-                      >
-                        <div className="flex items-center justify-center gap-1">
-                          <div className="truncate w-full" title={`${r.name} - クリックして編集`}>
-                            {r.name}
-                          </div>
-                          <Pencil className="h-3 w-3 text-gray-400 flex-shrink-0" />
-                        </div>
-                        {r.grade && (
-                          <div className="text-[10px] text-gray-500 truncate" title={r.grade}>
-                            {r.grade}
-                          </div>
-                        )}
+              <div className="inline-block min-w-max">
+                <table className="border-collapse text-xs">
+                  <thead className="sticky top-0 z-10 bg-white">
+                    <tr className="bg-gray-50 border-b">
+                      <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
+                        日時
                       </th>
-                    ))}
-                  </tr>
-                  <tr className="bg-gray-50 border-b">
-                    <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
-                      参加可能数
-                    </th>
-                    {sorted.map((r) => (
-                      <th
-                        key={`count-${r.id}`}
-                        className="py-0.5 px-1 text-center font-medium w-[8rem] min-w-[8rem] max-w-[8rem]"
-                      >
-                        {availableCounts[r.id] ?? 0}
+                      {sorted.map((r) => (
+                        <th
+                          key={r.id}
+                          className="py-0.5 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[8rem] min-w-[8rem] max-w-[8rem]"
+                          onClick={() => form.openEditDialog(r)}
+                        >
+                          <div className="flex items-center justify-center gap-1">
+                            <div className="truncate w-full" title={`${r.name} - クリックして編集`}>
+                              {r.name}
+                            </div>
+                            <Pencil className="h-3 w-3 text-gray-400 flex-shrink-0" />
+                          </div>
+                          {r.grade && (
+                            <div className="text-[10px] text-gray-500 truncate" title={r.grade}>
+                              {r.grade}
+                            </div>
+                          )}
+                        </th>
+                      ))}
+                    </tr>
+                    <tr className="bg-gray-50 border-b">
+                      <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
+                        参加可能数
                       </th>
+                      {sorted.map((r) => (
+                        <th
+                          key={`count-${r.id}`}
+                          className="py-0.5 px-1 text-center font-medium w-[8rem] min-w-[8rem] max-w-[8rem]"
+                        >
+                          {availableCounts[r.id] ?? 0}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {dateTimeOptions.map((dt, i) => (
+                      <tr key={i} className="hover:bg-gray-50">
+                        <td className="sticky left-0 bg-white z-10 border-r text-xs py-0.5 px-1.5 font-medium">
+                          {dt}
+                        </td>
+                        {sorted.map((r) => (
+                          <td
+                            key={`${dt}-${r.id}`}
+                            className={cn(
+                              "p-0 text-center align-middle w-[8rem] min-w-[8rem] max-w-[8rem]",
+                              getResponseCellClass(r, dt)
+                            )}
+                          >
+                            <div className="flex h-10 w-full items-center justify-center">
+                              {getResponseIcon(r, dt) || <Circle className="h-3 w-3 text-gray-200" />}
+                            </div>
+                          </td>
+                        ))}
+                      </tr>
                     ))}
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {dateTimeOptions.map((dt, i) => (
-                    <tr key={i} className="hover:bg-gray-50">
-                      <td className="sticky left-0 bg-white z-10 border-r text-xs py-0.5 px-1.5 font-medium">
-                        {dt}
+                    <tr className="bg-gray-50">
+                      <td className="sticky left-0 bg-gray-50 z-10 border-r text-xs py-0.5 px-1.5 font-medium align-top">
+                        コメント
                       </td>
                       {sorted.map((r) => (
                         <td
-                          key={`${dt}-${r.id}`}
-                          className={cn(
-                            "p-0 text-center align-middle w-[8rem] min-w-[8rem] max-w-[8rem]",
-                            getResponseCellClass(r, dt)
-                          )}
+                          key={`comment-${r.id}`}
+                          className="p-0 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
                         >
-                          <div className="flex h-10 w-full items-center justify-center">
-                            {getResponseIcon(r, dt) || <Circle className="h-3 w-3 text-gray-200" />}
-                          </div>
+                          {r.comment && r.comment.trim() !== "" ? (
+                            <div className="whitespace-pre-wrap break-words px-2 py-1 text-[10px] text-gray-500 leading-tight">
+                              {r.comment}
+                            </div>
+                          ) : (
+                            <div className="flex h-10 items-center justify-center text-[10px] text-gray-300">
+                              -
+                            </div>
+                          )}
                         </td>
                       ))}
                     </tr>
-                  ))}
-                  <tr className="bg-gray-50">
-                    <td className="sticky left-0 bg-gray-50 z-10 border-r text-xs py-0.5 px-1.5 font-medium align-top">
-                      コメント
-                    </td>
-                    {sorted.map((r) => (
-                      <td
-                        key={`comment-${r.id}`}
-                        className="p-0 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
-                      >
-                        {r.comment && r.comment.trim() !== "" ? (
-                          <div className="whitespace-pre-wrap break-words px-2 py-1 text-[10px] text-gray-500 leading-tight">
-                            {r.comment}
-                          </div>
-                        ) : (
-                          <div className="flex h-10 items-center justify-center text-[10px] text-gray-300">
-                            -
-                          </div>
-                        )}
-                      </td>
-                    ))}
-                  </tr>
-                </tbody>
-              </table>
+                  </tbody>
+                </table>
+              </div>
             </div>
           ) : (
             <div className="text-center py-8 text-gray-500">まだ回答がありません。</div>

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -256,11 +256,6 @@ export default function OneTimeResponsesTab({
                         <Pencil className="h-3 w-3 ml-1 text-gray-400" />
                       </div>
                       {r.grade && <div className="text-[10px] text-gray-500">{r.grade}</div>}
-                      {r.comment && r.comment.trim() !== "" && (
-                        <div className="mt-1 text-[10px] text-gray-400 whitespace-pre-wrap break-words max-w-[80px] mx-auto">
-                          {r.comment}
-                        </div>
-                      )}
                     </th>
                   ))}
                   </tr>
@@ -291,6 +286,23 @@ export default function OneTimeResponsesTab({
                       ))}
                     </tr>
                   ))}
+                  <tr className="bg-gray-50">
+                    <td className="sticky left-0 bg-gray-50 z-10 border-r text-xs py-1 px-2 font-medium align-top">
+                      コメント
+                    </td>
+                    {sorted.map((r) => (
+                      <td
+                        key={`comment-${r.id}`}
+                        className="py-1 px-1 text-left align-top"
+                      >
+                        {r.comment && r.comment.trim() !== "" && (
+                          <div className="text-[10px] text-gray-500 whitespace-pre-wrap break-words max-w-[80px]">
+                            {r.comment}
+                          </div>
+                        )}
+                      </td>
+                    ))}
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -240,13 +240,13 @@ export default function OneTimeResponsesTab({
               <table className="w-full border-collapse text-xs">
                 <thead className="sticky top-0 z-10 bg-white">
                   <tr className="bg-gray-50 border-b">
-                    <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-1 px-2 font-medium">
+                    <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
                       日時
                     </th>
                     {sorted.map((r) => (
                       <th
                         key={r.id}
-                        className="py-1 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[8rem] min-w-[8rem] max-w-[8rem]"
+                        className="py-0.5 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[8rem] min-w-[8rem] max-w-[8rem]"
                         onClick={() => form.openEditDialog(r)}
                       >
                         <div className="flex items-center justify-center gap-1">
@@ -264,13 +264,13 @@ export default function OneTimeResponsesTab({
                     ))}
                   </tr>
                   <tr className="bg-gray-50 border-b">
-                    <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-1 px-2 font-medium">
+                    <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
                       参加可能数
                     </th>
                     {sorted.map((r) => (
                       <th
                         key={`count-${r.id}`}
-                        className="py-1 px-1 text-center font-medium w-[8rem] min-w-[8rem] max-w-[8rem]"
+                        className="py-0.5 px-1 text-center font-medium w-[8rem] min-w-[8rem] max-w-[8rem]"
                       >
                         {availableCounts[r.id] ?? 0}
                       </th>
@@ -280,13 +280,13 @@ export default function OneTimeResponsesTab({
                 <tbody className="divide-y">
                   {dateTimeOptions.map((dt, i) => (
                     <tr key={i} className="hover:bg-gray-50">
-                      <td className="sticky left-0 bg-white z-10 border-r text-xs py-1 px-2 font-medium">
+                      <td className="sticky left-0 bg-white z-10 border-r text-xs py-0.5 px-1.5 font-medium">
                         {dt}
                       </td>
                       {sorted.map((r) => (
                         <td
                           key={`${dt}-${r.id}`}
-                          className={`py-1 px-1 text-center w-[8rem] min-w-[8rem] max-w-[8rem] ${getResponseCellClass(r, dt)}`}
+                          className={`py-0.5 px-1 text-center w-[8rem] min-w-[8rem] max-w-[8rem] ${getResponseCellClass(r, dt)}`}
                         >
                           {getResponseIcon(r, dt) || <Circle className="h-3 w-3 text-gray-200" />}
                         </td>
@@ -294,16 +294,16 @@ export default function OneTimeResponsesTab({
                     </tr>
                   ))}
                   <tr className="bg-gray-50">
-                    <td className="sticky left-0 bg-gray-50 z-10 border-r text-xs py-1 px-2 font-medium align-top">
+                    <td className="sticky left-0 bg-gray-50 z-10 border-r text-xs py-0.5 px-1.5 font-medium align-top">
                       コメント
                     </td>
                     {sorted.map((r) => (
                       <td
                         key={`comment-${r.id}`}
-                        className="py-1 px-1 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
+                        className="py-0.5 px-1 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
                       >
                         {r.comment && r.comment.trim() !== "" ? (
-                          <div className="text-[10px] text-gray-500 whitespace-pre-wrap break-words">
+                          <div className="text-[10px] text-gray-500 whitespace-pre-wrap break-words leading-tight">
                             {r.comment}
                           </div>
                         ) : (

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -246,7 +246,7 @@ export default function OneTimeResponsesTab({
                     {sorted.map((r) => (
                       <th
                         key={r.id}
-                        className="py-1 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[9rem] min-w-[9rem] max-w-[9rem]"
+                        className="py-1 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[8rem] min-w-[8rem] max-w-[8rem]"
                         onClick={() => form.openEditDialog(r)}
                       >
                         <div className="flex items-center justify-center gap-1">
@@ -270,7 +270,7 @@ export default function OneTimeResponsesTab({
                     {sorted.map((r) => (
                       <th
                         key={`count-${r.id}`}
-                        className="py-1 px-1 text-center font-medium w-[9rem] min-w-[9rem] max-w-[9rem]"
+                        className="py-1 px-1 text-center font-medium w-[8rem] min-w-[8rem] max-w-[8rem]"
                       >
                         {availableCounts[r.id] ?? 0}
                       </th>
@@ -286,7 +286,7 @@ export default function OneTimeResponsesTab({
                       {sorted.map((r) => (
                         <td
                           key={`${dt}-${r.id}`}
-                          className={`py-1 px-1 text-center w-[9rem] min-w-[9rem] max-w-[9rem] ${getResponseCellClass(r, dt)}`}
+                          className={`py-1 px-1 text-center w-[8rem] min-w-[8rem] max-w-[8rem] ${getResponseCellClass(r, dt)}`}
                         >
                           {getResponseIcon(r, dt) || <Circle className="h-3 w-3 text-gray-200" />}
                         </td>
@@ -300,7 +300,7 @@ export default function OneTimeResponsesTab({
                     {sorted.map((r) => (
                       <td
                         key={`comment-${r.id}`}
-                        className="py-1 px-1 text-left align-top w-[9rem] min-w-[9rem] max-w-[9rem]"
+                        className="py-1 px-1 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
                       >
                         {r.comment && r.comment.trim() !== "" ? (
                           <div className="text-[10px] text-gray-500 whitespace-pre-wrap break-words">

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -244,27 +244,34 @@ export default function OneTimeResponsesTab({
                       日時
                     </th>
                     {sorted.map((r) => (
-                    <th
-                      key={r.id}
-                      className="py-1 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100"
-                      onClick={() => form.openEditDialog(r)}
-                    >
-                      <div className="flex items-center justify-center">
-                        <div className="truncate max-w-[60px]" title={`${r.name} - クリックして編集`}>
-                          {r.name}
+                      <th
+                        key={r.id}
+                        className="py-1 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[9rem] min-w-[9rem] max-w-[9rem]"
+                        onClick={() => form.openEditDialog(r)}
+                      >
+                        <div className="flex items-center justify-center gap-1">
+                          <div className="truncate w-full" title={`${r.name} - クリックして編集`}>
+                            {r.name}
+                          </div>
+                          <Pencil className="h-3 w-3 text-gray-400 flex-shrink-0" />
                         </div>
-                        <Pencil className="h-3 w-3 ml-1 text-gray-400" />
-                      </div>
-                      {r.grade && <div className="text-[10px] text-gray-500">{r.grade}</div>}
-                    </th>
-                  ))}
+                        {r.grade && (
+                          <div className="text-[10px] text-gray-500 truncate" title={r.grade}>
+                            {r.grade}
+                          </div>
+                        )}
+                      </th>
+                    ))}
                   </tr>
                   <tr className="bg-gray-50 border-b">
                     <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-1 px-2 font-medium">
                       参加可能数
                     </th>
                     {sorted.map((r) => (
-                      <th key={`count-${r.id}`} className="py-1 px-1 text-center font-medium">
+                      <th
+                        key={`count-${r.id}`}
+                        className="py-1 px-1 text-center font-medium w-[9rem] min-w-[9rem] max-w-[9rem]"
+                      >
                         {availableCounts[r.id] ?? 0}
                       </th>
                     ))}
@@ -279,7 +286,7 @@ export default function OneTimeResponsesTab({
                       {sorted.map((r) => (
                         <td
                           key={`${dt}-${r.id}`}
-                          className={`py-1 px-1 text-center ${getResponseCellClass(r, dt)}`}
+                          className={`py-1 px-1 text-center w-[9rem] min-w-[9rem] max-w-[9rem] ${getResponseCellClass(r, dt)}`}
                         >
                           {getResponseIcon(r, dt) || <Circle className="h-3 w-3 text-gray-200" />}
                         </td>
@@ -293,12 +300,14 @@ export default function OneTimeResponsesTab({
                     {sorted.map((r) => (
                       <td
                         key={`comment-${r.id}`}
-                        className="py-1 px-1 text-left align-top"
+                        className="py-1 px-1 text-left align-top w-[9rem] min-w-[9rem] max-w-[9rem]"
                       >
-                        {r.comment && r.comment.trim() !== "" && (
-                          <div className="text-[10px] text-gray-500 whitespace-pre-wrap break-words max-w-[80px]">
+                        {r.comment && r.comment.trim() !== "" ? (
+                          <div className="text-[10px] text-gray-500 whitespace-pre-wrap break-words">
                             {r.comment}
                           </div>
+                        ) : (
+                          <span className="text-[10px] text-gray-300">-</span>
                         )}
                       </td>
                     ))}

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -78,10 +78,13 @@ export default function OneTimeResponsesTab({
     .filter((t) => t.isAvailable)
     .map((t) => t.id)
 
-  const availableCounts = sorted.reduce((acc, r) => {
-    acc[r.id] = r.schedule.filter((s) =>
-      availableTypeIds.includes(s.typeId)
-    ).length
+  const availableCountsByDate = dateTimeOptions.reduce((acc, dateTime) => {
+    const count = sorted.reduce((total, response) => {
+      const selection = response.schedule.find((s) => s.dateTime === dateTime)
+      if (!selection) return total
+      return availableTypeIds.includes(selection.typeId) ? total + 1 : total
+    }, 0)
+    acc[dateTime] = count
     return acc
   }, {} as Record<string, number>)
 
@@ -239,11 +242,15 @@ export default function OneTimeResponsesTab({
           {sorted.length > 0 ? (
             <div className="border rounded-md overflow-auto max-h-96">
               <div className="inline-block min-w-max">
+
                 <table className="border-collapse text-xs">
                   <thead className="sticky top-0 z-10 bg-white">
                     <tr className="bg-gray-50 border-b">
                       <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
                         日時
+                      </th>
+                      <th className="border-r py-0.5 px-1.5 text-center font-medium bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                        参加可能数
                       </th>
                       {sorted.map((r) => (
                         <th
@@ -265,25 +272,15 @@ export default function OneTimeResponsesTab({
                         </th>
                       ))}
                     </tr>
-                    <tr className="bg-gray-50 border-b">
-                      <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
-                        参加可能数
-                      </th>
-                      {sorted.map((r) => (
-                        <th
-                          key={`count-${r.id}`}
-                          className="py-0.5 px-1 text-center font-medium w-[8rem] min-w-[8rem] max-w-[8rem]"
-                        >
-                          {availableCounts[r.id] ?? 0}
-                        </th>
-                      ))}
-                    </tr>
                   </thead>
                   <tbody className="divide-y">
                     {dateTimeOptions.map((dt, i) => (
                       <tr key={i} className="hover:bg-gray-50">
                         <td className="sticky left-0 bg-white z-10 border-r text-xs py-0.5 px-1.5 font-medium">
                           {dt}
+                        </td>
+                        <td className="border-r bg-gray-50 text-center text-xs font-medium w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                          {availableCountsByDate[dt] ?? 0}
                         </td>
                         {sorted.map((r) => (
                           <td
@@ -304,6 +301,9 @@ export default function OneTimeResponsesTab({
                       <td className="sticky left-0 bg-gray-50 z-10 border-r text-xs py-0.5 px-1.5 font-medium align-top">
                         コメント
                       </td>
+                      <td className="border-r bg-gray-50 text-center text-[10px] text-gray-400 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                        -
+                      </td>
                       {sorted.map((r) => (
                         <td
                           key={`comment-${r.id}`}
@@ -323,6 +323,7 @@ export default function OneTimeResponsesTab({
                     </tr>
                   </tbody>
                 </table>
+
               </div>
             </div>
           ) : (

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -246,16 +246,18 @@ export default function OneTimeResponsesTab({
                 <table className="border-collapse text-xs">
                   <thead className="sticky top-0 z-10 bg-white">
                     <tr className="bg-gray-50 border-b">
-                      <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-0.5 px-1.5 font-medium">
+                      <th
+                        className="border px-1 py-0.5 text-left sticky left-0 top-0 bg-gray-50 z-30 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]"
+                      >
                         日時
                       </th>
-                      <th className="border-r py-0.5 px-1.5 text-center font-medium bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                      <th className="border px-1 py-0.5 text-center font-medium top-0 bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
                         参加可能数
                       </th>
                       {sorted.map((r) => (
                         <th
                           key={r.id}
-                          className="py-0.5 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100 w-[8rem] min-w-[8rem] max-w-[8rem]"
+                          className="border px-1 py-0.5 text-center align-top bg-gray-50 cursor-pointer hover:bg-gray-100 w-24 min-w-[6rem] max-w-[6rem]"
                           onClick={() => form.openEditDialog(r)}
                         >
                           <div className="flex items-center justify-center gap-1">
@@ -276,17 +278,17 @@ export default function OneTimeResponsesTab({
                   <tbody className="divide-y">
                     {dateTimeOptions.map((dt, i) => (
                       <tr key={i} className="hover:bg-gray-50">
-                        <td className="sticky left-0 bg-white z-10 border-r text-xs py-0.5 px-1.5 font-medium">
+                        <td className="border px-1 py-0.5 sticky left-0 bg-white z-20 align-top w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem] text-xs font-medium">
                           {dt}
                         </td>
-                        <td className="border-r bg-gray-50 text-center text-xs font-medium w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                        <td className="border px-1 py-0.5 bg-gray-50 text-center text-xs font-medium w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
                           {availableCountsByDate[dt] ?? 0}
                         </td>
                         {sorted.map((r) => (
                           <td
                             key={`${dt}-${r.id}`}
                             className={cn(
-                              "p-0 text-center align-middle w-[8rem] min-w-[8rem] max-w-[8rem]",
+                              "border p-0 text-center align-middle w-24 min-w-[6rem] max-w-[6rem]",
                               getResponseCellClass(r, dt)
                             )}
                           >
@@ -298,26 +300,24 @@ export default function OneTimeResponsesTab({
                       </tr>
                     ))}
                     <tr className="bg-gray-50">
-                      <td className="sticky left-0 bg-gray-50 z-10 border-r text-xs py-0.5 px-1.5 font-medium align-top">
+                      <td className="border px-1 py-0.5 text-left font-medium sticky left-0 bg-gray-50 z-20 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
                         コメント
                       </td>
-                      <td className="border-r bg-gray-50 text-center text-[10px] text-gray-400 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                      <td className="border px-1 py-0.5 bg-gray-50 text-center text-[10px] text-gray-400 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
                         -
                       </td>
                       {sorted.map((r) => (
                         <td
                           key={`comment-${r.id}`}
-                          className="p-0 text-left align-top w-[8rem] min-w-[8rem] max-w-[8rem]"
+                          className="border p-0 align-top text-left text-muted-foreground w-24 min-w-[6rem] max-w-[6rem]"
                         >
-                          {r.comment && r.comment.trim() !== "" ? (
-                            <div className="whitespace-pre-wrap break-words px-2 py-1 text-[10px] text-gray-500 leading-tight">
-                              {r.comment}
-                            </div>
-                          ) : (
-                            <div className="flex h-10 items-center justify-center text-[10px] text-gray-300">
-                              -
-                            </div>
-                          )}
+                          <div className="whitespace-pre-wrap break-words px-2 py-1 text-xs">
+                            {r.comment && r.comment.trim() !== "" ? (
+                              r.comment
+                            ) : (
+                              <span className="text-gray-300">-</span>
+                            )}
+                          </div>
                         </td>
                       ))}
                     </tr>

--- a/app/events/[eventId]/components/OneTimeResponseStatus.tsx
+++ b/app/events/[eventId]/components/OneTimeResponseStatus.tsx
@@ -48,20 +48,10 @@ export default function OneTimeResponsesTab({
 
     if (type.isAvailable) {
       return (
-        <CheckCircle2
-          className="h-4 w-4 text-green-500"
-          role="img"
-          aria-label={`${type.label}${selection.comment ? `: ${selection.comment}` : ""}`}
-        />
+        <CheckCircle2 className="h-4 w-4 text-green-500" role="img" aria-label={type.label} />
       )
     } else {
-      return (
-        <XCircle
-          className="h-4 w-4 text-red-500"
-          role="img"
-          aria-label={`${type.label}${selection.comment ? `: ${selection.comment}` : ""}`}
-        />
-      )
+      return <XCircle className="h-4 w-4 text-red-500" role="img" aria-label={type.label} />
     }
   }
 
@@ -254,20 +244,25 @@ export default function OneTimeResponsesTab({
                       日時
                     </th>
                     {sorted.map((r) => (
-                      <th
-                        key={r.id}
-                        className="py-1 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100"
-                        onClick={() => form.openEditDialog(r)}
-                      >
-                        <div className="flex items-center justify-center">
-                          <div className="truncate max-w-[60px]" title={`${r.name} - クリックして編集`}>
-                            {r.name}
-                          </div>
-                          <Pencil className="h-3 w-3 ml-1 text-gray-400" />
+                    <th
+                      key={r.id}
+                      className="py-1 px-1 text-center font-medium whitespace-nowrap cursor-pointer hover:bg-gray-100"
+                      onClick={() => form.openEditDialog(r)}
+                    >
+                      <div className="flex items-center justify-center">
+                        <div className="truncate max-w-[60px]" title={`${r.name} - クリックして編集`}>
+                          {r.name}
                         </div>
-                        {r.grade && <div className="text-[10px] text-gray-500">{r.grade}</div>}
-                      </th>
-                    ))}
+                        <Pencil className="h-3 w-3 ml-1 text-gray-400" />
+                      </div>
+                      {r.grade && <div className="text-[10px] text-gray-500">{r.grade}</div>}
+                      {r.comment && r.comment.trim() !== "" && (
+                        <div className="mt-1 text-[10px] text-gray-400 whitespace-pre-wrap break-words max-w-[80px] mx-auto">
+                          {r.comment}
+                        </div>
+                      )}
+                    </th>
+                  ))}
                   </tr>
                   <tr className="bg-gray-50 border-b">
                     <th className="sticky left-0 bg-gray-50 z-10 border-r text-left py-1 px-2 font-medium">

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -227,7 +227,7 @@ export default function ParticipantList({
                 {displayed.map((part, idx) => (
                   <th
                     key={part.id}
-                    className="border px-1 py-0.5 text-center align-top bg-gray-50 cursor-pointer hover:bg-gray-100"
+                    className="border px-1 py-0.5 text-center align-top bg-gray-50 cursor-pointer hover:bg-gray-100 w-24 min-w-[6rem] max-w-[6rem]"
                     onClick={() => handleEdit(idx)}
                     title={isEnglish ? 'Click to edit' : 'クリックして編集'}
                   >
@@ -265,7 +265,7 @@ export default function ParticipantList({
                       return (
                         <td
                           key={`${part.id}-${key}`}
-                          className="border p-0 text-center align-middle"
+                          className="border p-0 text-center align-middle w-24 min-w-[6rem] max-w-[6rem]"
                         >
                           <div
                             className={cn(
@@ -289,7 +289,7 @@ export default function ParticipantList({
                 {displayed.map((part) => (
                   <td
                     key={`comment-${part.id}`}
-                    className="border p-0 align-top text-left text-muted-foreground"
+                    className="border p-0 align-top text-left text-muted-foreground w-24 min-w-[6rem] max-w-[6rem]"
                   >
                     <div className="whitespace-pre-wrap break-words px-2 py-1 text-xs">
                       {part.comment && part.comment.trim() !== '' ? (

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -211,9 +211,6 @@ export default function ParticipantList({
                 <th className="border p-1 sticky left-0 bg-white z-20">
                   {isEnglish ? 'Name' : '名前'}
                 </th>
-                <th className="border p-1 text-left align-top min-w-[160px]">
-                  {isEnglish ? 'Comment' : 'コメント'}
-                </th>
                 {xAxis.map((day) =>
                   yAxis.map((period) => (
                     <th
@@ -224,12 +221,14 @@ export default function ParticipantList({
                     </th>
                   ))
                 )}
+                <th className="border p-1 text-left align-top min-w-[160px]">
+                  {isEnglish ? 'Comment' : 'コメント'}
+                </th>
               </tr>
               <tr className="bg-gray-50">
                 <th className="border p-1 text-center sticky left-0 bg-gray-50 z-20">
                   {isEnglish ? 'Available Participants' : '参加可能者数'}
                 </th>
-                <th className="border p-1 text-center">-</th>
                 {xAxis.map((day) =>
                   yAxis.map((period) => (
                     <th
@@ -240,6 +239,7 @@ export default function ParticipantList({
                     </th>
                   ))
                 )}
+                <th className="border p-1 text-center">-</th>
               </tr>
             </thead>
             <tbody>
@@ -250,13 +250,6 @@ export default function ParticipantList({
                     onClick={() => handleEdit(idx)}
                   >
                     {part.grade}: {part.name}
-                  </td>
-                  <td className="border p-1 align-top text-sm whitespace-pre-wrap text-left text-muted-foreground">
-                    {part.comment && part.comment.trim() !== '' ? (
-                      part.comment
-                    ) : (
-                      <span className="text-gray-300">-</span>
-                    )}
                   </td>
                   {xAxis.map((day) =>
                     yAxis.map((period) => {
@@ -280,6 +273,13 @@ export default function ParticipantList({
                       )
                     })
                   )}
+                  <td className="border p-1 align-top text-sm whitespace-pre-wrap text-left text-muted-foreground">
+                    {part.comment && part.comment.trim() !== '' ? (
+                      part.comment
+                    ) : (
+                      <span className="text-gray-300">-</span>
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -215,94 +215,96 @@ export default function ParticipantList({
       {/* ── グリッドビュー ── */}
       {viewMode === 'grid' ? (
         <div className="overflow-x-auto">
-          <table className="w-full border-collapse text-sm">
-            <thead className="sticky top-0 z-10 bg-white">
-              <tr className="bg-gray-50">
-                <th className="border px-1 py-0.5 text-left sticky left-0 top-0 bg-gray-50 z-30 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
-                  {isEnglish ? 'Time Slot' : '日時'}
-                </th>
-                <th className="border px-1 py-0.5 text-center font-medium top-0 bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
-                  {isEnglish ? 'Available' : '参加可能数'}
-                </th>
-                {displayed.map((part, idx) => (
-                  <th
-                    key={part.id}
-                    className="border px-1 py-0.5 text-center align-top bg-gray-50 cursor-pointer hover:bg-gray-100 w-24 min-w-[6rem] max-w-[6rem]"
-                    onClick={() => handleEdit(idx)}
-                    title={isEnglish ? 'Click to edit' : 'クリックして編集'}
-                  >
-                    <div className="font-semibold truncate" title={part.name}>
-                      {part.name}
-                    </div>
-                    {part.grade && (
-                      <div className="text-[10px] text-gray-500 truncate" title={part.grade}>
-                        {part.grade}
-                      </div>
-                    )}
+          <div className="inline-block min-w-max">
+            <table className="border-collapse text-sm">
+              <thead className="sticky top-0 z-10 bg-white">
+                <tr className="bg-gray-50">
+                  <th className="border px-1 py-0.5 text-left sticky left-0 top-0 bg-gray-50 z-30 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
+                    {isEnglish ? 'Time Slot' : '日時'}
                   </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {slotDescriptors.map(({ key, day, period }) => {
-                const periodLabel = isEnglish
-                  ? period
-                  : /^\d+$/.test(period)
-                  ? `${period}限`
-                  : period
-                return (
-                  <tr key={key} className="hover:bg-gray-50">
-                    <td className="border px-1 py-0.5 sticky left-0 bg-white z-20 align-top w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
-                      <div className="font-medium">{day}</div>
-                      <div className="text-[11px] text-gray-500">{periodLabel}</div>
-                    </td>
-                    <td className="border px-1 py-0.5 text-center font-medium bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
-                      {availableCounts[key] ?? 0}
-                    </td>
-                    {displayed.map((part) => {
-                      const value = part.schedule[key]
-                      const type = scheduleTypes.find((t) => t.id === value)
-                      return (
-                        <td
-                          key={`${part.id}-${key}`}
-                          className="border p-0 text-center align-middle w-24 min-w-[6rem] max-w-[6rem]"
-                        >
-                          <div
-                            className={cn(
-                              'flex h-10 w-full items-center justify-center text-xs font-medium',
-                              value && type?.color ? type.color : 'bg-white text-gray-300'
-                            )}
-                          >
-                            {value && type?.label ? type.label : '-'}
-                          </div>
-                        </td>
-                      )
-                    })}
-                  </tr>
-                )
-              })}
-              <tr className="bg-gray-50">
-                <td className="border px-1 py-0.5 text-left font-medium sticky left-0 bg-gray-50 z-20 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
-                  {isEnglish ? 'Comment' : 'コメント'}
-                </td>
-                <td className="border px-1 py-0.5 text-center bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">-</td>
-                {displayed.map((part) => (
-                  <td
-                    key={`comment-${part.id}`}
-                    className="border p-0 align-top text-left text-muted-foreground w-24 min-w-[6rem] max-w-[6rem]"
-                  >
-                    <div className="whitespace-pre-wrap break-words px-2 py-1 text-xs">
-                      {part.comment && part.comment.trim() !== '' ? (
-                        part.comment
-                      ) : (
-                        <span className="text-gray-300">-</span>
+                  <th className="border px-1 py-0.5 text-center font-medium top-0 bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                    {isEnglish ? 'Available' : '参加可能数'}
+                  </th>
+                  {displayed.map((part, idx) => (
+                    <th
+                      key={part.id}
+                      className="border px-1 py-0.5 text-center align-top bg-gray-50 cursor-pointer hover:bg-gray-100 w-24 min-w-[6rem] max-w-[6rem]"
+                      onClick={() => handleEdit(idx)}
+                      title={isEnglish ? 'Click to edit' : 'クリックして編集'}
+                    >
+                      <div className="font-semibold truncate" title={part.name}>
+                        {part.name}
+                      </div>
+                      {part.grade && (
+                        <div className="text-[10px] text-gray-500 truncate" title={part.grade}>
+                          {part.grade}
+                        </div>
                       )}
-                    </div>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {slotDescriptors.map(({ key, day, period }) => {
+                  const periodLabel = isEnglish
+                    ? period
+                    : /^\d+$/.test(period)
+                    ? `${period}限`
+                    : period
+                  return (
+                    <tr key={key} className="hover:bg-gray-50">
+                      <td className="border px-1 py-0.5 sticky left-0 bg-white z-20 align-top w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
+                        <div className="font-medium">{day}</div>
+                        <div className="text-[11px] text-gray-500">{periodLabel}</div>
+                      </td>
+                      <td className="border px-1 py-0.5 text-center font-medium bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
+                        {availableCounts[key] ?? 0}
+                      </td>
+                      {displayed.map((part) => {
+                        const value = part.schedule[key]
+                        const type = scheduleTypes.find((t) => t.id === value)
+                        return (
+                          <td
+                            key={`${part.id}-${key}`}
+                            className="border p-0 text-center align-middle w-24 min-w-[6rem] max-w-[6rem]"
+                          >
+                            <div
+                              className={cn(
+                                'flex h-10 w-full items-center justify-center text-xs font-medium',
+                                value && type?.color ? type.color : 'bg-white text-gray-300'
+                              )}
+                            >
+                              {value && type?.label ? type.label : '-'}
+                            </div>
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  )
+                })}
+                <tr className="bg-gray-50">
+                  <td className="border px-1 py-0.5 text-left font-medium sticky left-0 bg-gray-50 z-20 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
+                    {isEnglish ? 'Comment' : 'コメント'}
                   </td>
-                ))}
-              </tr>
-            </tbody>
-          </table>
+                  <td className="border px-1 py-0.5 text-center bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">-</td>
+                  {displayed.map((part) => (
+                    <td
+                      key={`comment-${part.id}`}
+                      className="border p-0 align-top text-left text-muted-foreground w-24 min-w-[6rem] max-w-[6rem]"
+                    >
+                      <div className="whitespace-pre-wrap break-words px-2 py-1 text-xs">
+                        {part.comment && part.comment.trim() !== '' ? (
+                          part.comment
+                        ) : (
+                          <span className="text-gray-300">-</span>
+                        )}
+                      </div>
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       ) : (
         /* ── リストビュー（既存カード） ── */

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -217,16 +217,16 @@ export default function ParticipantList({
           <table className="w-full border-collapse text-sm">
             <thead className="sticky top-0 z-10 bg-white">
               <tr className="bg-gray-50">
-                <th className="border p-1 text-left sticky left-0 top-0 bg-gray-50 z-30">
+                <th className="border px-1 py-0.5 text-left sticky left-0 top-0 bg-gray-50 z-30">
                   {isEnglish ? 'Time Slot' : '日時'}
                 </th>
-                <th className="border p-1 text-center font-medium top-0 bg-gray-50">
+                <th className="border px-1 py-0.5 text-center font-medium top-0 bg-gray-50">
                   {isEnglish ? 'Available' : '参加可能数'}
                 </th>
                 {displayed.map((part, idx) => (
                   <th
                     key={part.id}
-                    className="border p-1 text-center align-top w-[8rem] min-w-[8rem] max-w-[8rem] bg-gray-50 cursor-pointer hover:bg-gray-100"
+                    className="border px-1 py-0.5 text-center align-top w-[8rem] min-w-[8rem] max-w-[8rem] bg-gray-50 cursor-pointer hover:bg-gray-100"
                     onClick={() => handleEdit(idx)}
                     title={isEnglish ? 'Click to edit' : 'クリックして編集'}
                   >
@@ -251,11 +251,11 @@ export default function ParticipantList({
                   : period
                 return (
                   <tr key={key} className="hover:bg-gray-50">
-                    <td className="border p-1 sticky left-0 bg-white z-20 align-top">
+                    <td className="border px-1 py-0.5 sticky left-0 bg-white z-20 align-top">
                       <div className="font-medium">{day}</div>
                       <div className="text-[11px] text-gray-500">{periodLabel}</div>
                     </td>
-                    <td className="border p-1 text-center font-medium bg-gray-50">
+                    <td className="border px-1 py-0.5 text-center font-medium bg-gray-50">
                       {availableCounts[key] ?? 0}
                     </td>
                     {displayed.map((part) => {
@@ -264,11 +264,11 @@ export default function ParticipantList({
                       return (
                         <td
                           key={`${part.id}-${key}`}
-                          className="border p-1 text-center w-[8rem] min-w-[8rem] max-w-[8rem]"
+                          className="border px-1 py-0.5 text-center w-[8rem] min-w-[8rem] max-w-[8rem]"
                         >
                           {value ? (
                             <span
-                              className={`px-1.5 py-0.5 rounded text-xs ${
+                              className={`inline-flex items-center justify-center px-1 py-px rounded text-xs leading-tight ${
                                 type?.color || ''
                               }`}
                             >
@@ -284,14 +284,14 @@ export default function ParticipantList({
                 )
               })}
               <tr className="bg-gray-50">
-                <td className="border p-1 text-left font-medium sticky left-0 bg-gray-50 z-20">
+                <td className="border px-1 py-0.5 text-left font-medium sticky left-0 bg-gray-50 z-20">
                   {isEnglish ? 'Comment' : 'コメント'}
                 </td>
-                <td className="border p-1 text-center bg-gray-50">-</td>
+                <td className="border px-1 py-0.5 text-center bg-gray-50">-</td>
                 {displayed.map((part) => (
                   <td
                     key={`comment-${part.id}`}
-                    className="border p-1 align-top text-xs whitespace-pre-wrap break-words text-left text-muted-foreground w-[8rem] min-w-[8rem] max-w-[8rem]"
+                    className="border px-1 py-0.5 align-top text-xs whitespace-pre-wrap break-words text-left text-muted-foreground w-[8rem] min-w-[8rem] max-w-[8rem]"
                   >
                     {part.comment && part.comment.trim() !== '' ? (
                       part.comment

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -226,15 +226,15 @@ export default function ParticipantList({
                 {displayed.map((part, idx) => (
                   <th
                     key={part.id}
-                    className="border p-1 text-center align-top min-w-[110px] bg-gray-50 cursor-pointer hover:bg-gray-100"
+                    className="border p-1 text-center align-top w-[10rem] min-w-[10rem] max-w-[10rem] bg-gray-50 cursor-pointer hover:bg-gray-100"
                     onClick={() => handleEdit(idx)}
                     title={isEnglish ? 'Click to edit' : 'クリックして編集'}
                   >
-                    <div className="font-semibold truncate" title={part.name}>
+                    <div className="font-semibold truncate w-full" title={part.name}>
                       {part.name}
                     </div>
                     {part.grade && (
-                      <div className="text-[10px] text-gray-500 truncate" title={part.grade}>
+                      <div className="text-[10px] text-gray-500 truncate w-full" title={part.grade}>
                         {part.grade}
                       </div>
                     )}
@@ -262,7 +262,10 @@ export default function ParticipantList({
                       const value = part.schedule[key]
                       const type = scheduleTypes.find((t) => t.id === value)
                       return (
-                        <td key={`${part.id}-${key}`} className="border p-1 text-center">
+                        <td
+                          key={`${part.id}-${key}`}
+                          className="border p-1 text-center w-[10rem] min-w-[10rem] max-w-[10rem]"
+                        >
                           {value ? (
                             <span
                               className={`px-2 py-1 rounded text-xs ${
@@ -288,7 +291,7 @@ export default function ParticipantList({
                 {displayed.map((part) => (
                   <td
                     key={`comment-${part.id}`}
-                    className="border p-1 align-top text-xs whitespace-pre-wrap text-left text-muted-foreground"
+                    className="border p-1 align-top text-xs whitespace-pre-wrap break-words text-left text-muted-foreground w-[10rem] min-w-[10rem] max-w-[10rem]"
                   >
                     {part.comment && part.comment.trim() !== '' ? (
                       part.comment

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -226,15 +226,21 @@ export default function ParticipantList({
                 {displayed.map((part, idx) => (
                   <th
                     key={part.id}
-                    className="border px-1 py-0.5 text-center align-top w-[8rem] min-w-[8rem] max-w-[8rem] bg-gray-50 cursor-pointer hover:bg-gray-100"
+                    className="border px-1 py-0.5 text-center align-top bg-gray-50 cursor-pointer hover:bg-gray-100"
                     onClick={() => handleEdit(idx)}
                     title={isEnglish ? 'Click to edit' : 'クリックして編集'}
                   >
-                    <div className="font-semibold truncate w-full" title={part.name}>
+                    <div
+                      className="font-semibold truncate max-w-[5rem] mx-auto"
+                      title={part.name}
+                    >
                       {part.name}
                     </div>
                     {part.grade && (
-                      <div className="text-[10px] text-gray-500 truncate w-full" title={part.grade}>
+                      <div
+                        className="text-[10px] text-gray-500 truncate max-w-[5rem] mx-auto"
+                        title={part.grade}
+                      >
                         {part.grade}
                       </div>
                     )}
@@ -264,19 +270,21 @@ export default function ParticipantList({
                       return (
                         <td
                           key={`${part.id}-${key}`}
-                          className="border px-1 py-0.5 text-center w-[8rem] min-w-[8rem] max-w-[8rem]"
+                          className="border px-1 py-0.5 text-center align-top"
                         >
-                          {value ? (
-                            <span
-                              className={`inline-flex items-center justify-center px-1 py-px rounded text-xs leading-tight ${
-                                type?.color || ''
-                              }`}
-                            >
-                              {type?.label}
-                            </span>
-                          ) : (
-                            <span className="text-gray-300">-</span>
-                          )}
+                          <div className="max-w-[5rem] mx-auto">
+                            {value ? (
+                              <span
+                                className={`inline-flex flex-wrap items-center justify-center px-1 py-px rounded text-xs leading-tight text-center ${
+                                  type?.color || ''
+                                }`}
+                              >
+                                {type?.label}
+                              </span>
+                            ) : (
+                              <span className="text-gray-300">-</span>
+                            )}
+                          </div>
                         </td>
                       )
                     })}
@@ -291,13 +299,15 @@ export default function ParticipantList({
                 {displayed.map((part) => (
                   <td
                     key={`comment-${part.id}`}
-                    className="border px-1 py-0.5 align-top text-xs whitespace-pre-wrap break-words text-left text-muted-foreground w-[8rem] min-w-[8rem] max-w-[8rem]"
+                    className="border px-1 py-0.5 align-top text-left text-muted-foreground"
                   >
-                    {part.comment && part.comment.trim() !== '' ? (
-                      part.comment
-                    ) : (
-                      <span className="text-gray-300">-</span>
-                    )}
+                    <div className="max-w-[5rem] whitespace-pre-wrap break-words text-xs">
+                      {part.comment && part.comment.trim() !== '' ? (
+                        part.comment
+                      ) : (
+                        <span className="text-gray-300">-</span>
+                      )}
+                    </div>
                   </td>
                 ))}
               </tr>

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -79,18 +79,27 @@ export default function ParticipantList({
     return sortAscending ? ai - bi : bi - ai
   })
 
+  const slotDescriptors = useMemo(
+    () =>
+      xAxis.flatMap((day) =>
+        yAxis.map((period) => ({
+          key: `${day}-${period}`,
+          day,
+          period: String(period),
+        }))
+      ),
+    [xAxis, yAxis]
+  )
+
   const availableCounts = useMemo(() => {
     const counts: Record<string, number> = {}
-    for (const day of xAxis) {
-      for (const period of yAxis) {
-        const key = `${day}-${period}`
-        counts[key] = displayed.filter((p) =>
-          availableOptions.includes(p.schedule[key])
-        ).length
-      }
+    for (const slot of slotDescriptors) {
+      counts[slot.key] = displayed.filter((p) =>
+        availableOptions.includes(p.schedule[slot.key])
+      ).length
     }
     return counts
-  }, [displayed, xAxis, yAxis, availableOptions])
+  }, [displayed, slotDescriptors, availableOptions])
 
   const handleEdit = (idx: number) => {
     const part = displayed[idx]
@@ -207,81 +216,88 @@ export default function ParticipantList({
         <div className="overflow-x-auto">
           <table className="w-full border-collapse text-sm">
             <thead className="sticky top-0 z-10 bg-white">
-              <tr>
-                <th className="border p-1 sticky left-0 bg-white z-20">
-                  {isEnglish ? 'Name' : '名前'}
-                </th>
-                {xAxis.map((day) =>
-                  yAxis.map((period) => (
-                    <th
-                      key={`${day}-${period}`}
-                      className="border p-1 text-center whitespace-nowrap"
-                    >
-                      {`${day}${period}`}
-                    </th>
-                  ))
-                )}
-                <th className="border p-1 text-left align-top min-w-[160px]">
-                  {isEnglish ? 'Comment' : 'コメント'}
-                </th>
-              </tr>
               <tr className="bg-gray-50">
-                <th className="border p-1 text-center sticky left-0 bg-gray-50 z-20">
-                  {isEnglish ? 'Available Participants' : '参加可能者数'}
+                <th className="border p-1 text-left sticky left-0 top-0 bg-gray-50 z-30">
+                  {isEnglish ? 'Time Slot' : '日時'}
                 </th>
-                {xAxis.map((day) =>
-                  yAxis.map((period) => (
-                    <th
-                      key={`count-${day}-${period}`}
-                      className="border p-1 text-center"
-                    >
-                      {availableCounts[`${day}-${period}`] ?? 0}
-                    </th>
-                  ))
-                )}
-                <th className="border p-1 text-center">-</th>
+                <th className="border p-1 text-center font-medium top-0 bg-gray-50">
+                  {isEnglish ? 'Available' : '参加可能数'}
+                </th>
+                {displayed.map((part, idx) => (
+                  <th
+                    key={part.id}
+                    className="border p-1 text-center align-top min-w-[110px] bg-gray-50 cursor-pointer hover:bg-gray-100"
+                    onClick={() => handleEdit(idx)}
+                    title={isEnglish ? 'Click to edit' : 'クリックして編集'}
+                  >
+                    <div className="font-semibold truncate" title={part.name}>
+                      {part.name}
+                    </div>
+                    {part.grade && (
+                      <div className="text-[10px] text-gray-500 truncate" title={part.grade}>
+                        {part.grade}
+                      </div>
+                    )}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
-              {displayed.map((part, idx) => (
-                <tr key={part.id}>
-                  <td
-                    className="border p-1 font-medium sticky left-0 bg-white z-10 cursor-pointer hover:bg-gray-100"
-                    onClick={() => handleEdit(idx)}
-                  >
-                    {part.grade}: {part.name}
-                  </td>
-                  {xAxis.map((day) =>
-                    yAxis.map((period) => {
-                      const key = `${day}-${period}`
+              {slotDescriptors.map(({ key, day, period }) => {
+                const periodLabel = isEnglish
+                  ? period
+                  : /^\d+$/.test(period)
+                  ? `${period}限`
+                  : period
+                return (
+                  <tr key={key} className="hover:bg-gray-50">
+                    <td className="border p-1 sticky left-0 bg-white z-20 align-top">
+                      <div className="font-medium">{day}</div>
+                      <div className="text-[11px] text-gray-500">{periodLabel}</div>
+                    </td>
+                    <td className="border p-1 text-center font-medium bg-gray-50">
+                      {availableCounts[key] ?? 0}
+                    </td>
+                    {displayed.map((part) => {
                       const value = part.schedule[key]
                       const type = scheduleTypes.find((t) => t.id === value)
                       return (
-                        <td key={key} className="border p-1 text-center">
+                        <td key={`${part.id}-${key}`} className="border p-1 text-center">
                           {value ? (
                             <span
                               className={`px-2 py-1 rounded text-xs ${
-                                type?.color
+                                type?.color || ''
                               }`}
                             >
                               {type?.label}
                             </span>
                           ) : (
-                            '-'
+                            <span className="text-gray-300">-</span>
                           )}
                         </td>
                       )
-                    })
-                  )}
-                  <td className="border p-1 align-top text-sm whitespace-pre-wrap text-left text-muted-foreground">
+                    })}
+                  </tr>
+                )
+              })}
+              <tr className="bg-gray-50">
+                <td className="border p-1 text-left font-medium sticky left-0 bg-gray-50 z-20">
+                  {isEnglish ? 'Comment' : 'コメント'}
+                </td>
+                <td className="border p-1 text-center bg-gray-50">-</td>
+                {displayed.map((part) => (
+                  <td
+                    key={`comment-${part.id}`}
+                    className="border p-1 align-top text-xs whitespace-pre-wrap text-left text-muted-foreground"
+                  >
                     {part.comment && part.comment.trim() !== '' ? (
                       part.comment
                     ) : (
                       <span className="text-gray-300">-</span>
                     )}
                   </td>
-                </tr>
-              ))}
+                ))}
+              </tr>
             </tbody>
           </table>
         </div>

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/select'
 import { useMediaQuery } from '@/hooks/use-mobile'
 import { toast } from '@/components/ui/use-toast'
+import { cn } from '@/lib/utils'
 import { useParams, usePathname } from 'next/navigation'
 import type { Participant } from './types'
 import type { ScheduleType } from './constants'
@@ -230,17 +231,11 @@ export default function ParticipantList({
                     onClick={() => handleEdit(idx)}
                     title={isEnglish ? 'Click to edit' : 'クリックして編集'}
                   >
-                    <div
-                      className="font-semibold truncate max-w-[5rem] mx-auto"
-                      title={part.name}
-                    >
+                    <div className="font-semibold truncate" title={part.name}>
                       {part.name}
                     </div>
                     {part.grade && (
-                      <div
-                        className="text-[10px] text-gray-500 truncate max-w-[5rem] mx-auto"
-                        title={part.grade}
-                      >
+                      <div className="text-[10px] text-gray-500 truncate" title={part.grade}>
                         {part.grade}
                       </div>
                     )}
@@ -270,20 +265,15 @@ export default function ParticipantList({
                       return (
                         <td
                           key={`${part.id}-${key}`}
-                          className="border px-1 py-0.5 text-center align-top"
+                          className="border p-0 text-center align-middle"
                         >
-                          <div className="max-w-[5rem] mx-auto">
-                            {value ? (
-                              <span
-                                className={`inline-flex flex-wrap items-center justify-center px-1 py-px rounded text-xs leading-tight text-center ${
-                                  type?.color || ''
-                                }`}
-                              >
-                                {type?.label}
-                              </span>
-                            ) : (
-                              <span className="text-gray-300">-</span>
+                          <div
+                            className={cn(
+                              'flex h-10 w-full items-center justify-center text-xs font-medium',
+                              value && type?.color ? type.color : 'bg-white text-gray-300'
                             )}
+                          >
+                            {value && type?.label ? type.label : '-'}
                           </div>
                         </td>
                       )
@@ -299,9 +289,9 @@ export default function ParticipantList({
                 {displayed.map((part) => (
                   <td
                     key={`comment-${part.id}`}
-                    className="border px-1 py-0.5 align-top text-left text-muted-foreground"
+                    className="border p-0 align-top text-left text-muted-foreground"
                   >
-                    <div className="max-w-[5rem] whitespace-pre-wrap break-words text-xs">
+                    <div className="whitespace-pre-wrap break-words px-2 py-1 text-xs">
                       {part.comment && part.comment.trim() !== '' ? (
                         part.comment
                       ) : (

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -226,7 +226,7 @@ export default function ParticipantList({
                 {displayed.map((part, idx) => (
                   <th
                     key={part.id}
-                    className="border p-1 text-center align-top w-[10rem] min-w-[10rem] max-w-[10rem] bg-gray-50 cursor-pointer hover:bg-gray-100"
+                    className="border p-1 text-center align-top w-[8rem] min-w-[8rem] max-w-[8rem] bg-gray-50 cursor-pointer hover:bg-gray-100"
                     onClick={() => handleEdit(idx)}
                     title={isEnglish ? 'Click to edit' : 'クリックして編集'}
                   >
@@ -264,11 +264,11 @@ export default function ParticipantList({
                       return (
                         <td
                           key={`${part.id}-${key}`}
-                          className="border p-1 text-center w-[10rem] min-w-[10rem] max-w-[10rem]"
+                          className="border p-1 text-center w-[8rem] min-w-[8rem] max-w-[8rem]"
                         >
                           {value ? (
                             <span
-                              className={`px-2 py-1 rounded text-xs ${
+                              className={`px-1.5 py-0.5 rounded text-xs ${
                                 type?.color || ''
                               }`}
                             >
@@ -291,7 +291,7 @@ export default function ParticipantList({
                 {displayed.map((part) => (
                   <td
                     key={`comment-${part.id}`}
-                    className="border p-1 align-top text-xs whitespace-pre-wrap break-words text-left text-muted-foreground w-[10rem] min-w-[10rem] max-w-[10rem]"
+                    className="border p-1 align-top text-xs whitespace-pre-wrap break-words text-left text-muted-foreground w-[8rem] min-w-[8rem] max-w-[8rem]"
                   >
                     {part.comment && part.comment.trim() !== '' ? (
                       part.comment

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -218,10 +218,10 @@ export default function ParticipantList({
           <table className="w-full border-collapse text-sm">
             <thead className="sticky top-0 z-10 bg-white">
               <tr className="bg-gray-50">
-                <th className="border px-1 py-0.5 text-left sticky left-0 top-0 bg-gray-50 z-30">
+                <th className="border px-1 py-0.5 text-left sticky left-0 top-0 bg-gray-50 z-30 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
                   {isEnglish ? 'Time Slot' : '日時'}
                 </th>
-                <th className="border px-1 py-0.5 text-center font-medium top-0 bg-gray-50">
+                <th className="border px-1 py-0.5 text-center font-medium top-0 bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
                   {isEnglish ? 'Available' : '参加可能数'}
                 </th>
                 {displayed.map((part, idx) => (
@@ -252,11 +252,11 @@ export default function ParticipantList({
                   : period
                 return (
                   <tr key={key} className="hover:bg-gray-50">
-                    <td className="border px-1 py-0.5 sticky left-0 bg-white z-20 align-top">
+                    <td className="border px-1 py-0.5 sticky left-0 bg-white z-20 align-top w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
                       <div className="font-medium">{day}</div>
                       <div className="text-[11px] text-gray-500">{periodLabel}</div>
                     </td>
-                    <td className="border px-1 py-0.5 text-center font-medium bg-gray-50">
+                    <td className="border px-1 py-0.5 text-center font-medium bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">
                       {availableCounts[key] ?? 0}
                     </td>
                     {displayed.map((part) => {
@@ -282,10 +282,10 @@ export default function ParticipantList({
                 )
               })}
               <tr className="bg-gray-50">
-                <td className="border px-1 py-0.5 text-left font-medium sticky left-0 bg-gray-50 z-20">
+                <td className="border px-1 py-0.5 text-left font-medium sticky left-0 bg-gray-50 z-20 w-[5.5rem] min-w-[5.5rem] max-w-[5.5rem]">
                   {isEnglish ? 'Comment' : 'コメント'}
                 </td>
-                <td className="border px-1 py-0.5 text-center bg-gray-50">-</td>
+                <td className="border px-1 py-0.5 text-center bg-gray-50 w-[3.5rem] min-w-[3.5rem] max-w-[3.5rem]">-</td>
                 {displayed.map((part) => (
                   <td
                     key={`comment-${part.id}`}

--- a/app/events/[eventId]/components/ParticipantList.tsx
+++ b/app/events/[eventId]/components/ParticipantList.tsx
@@ -29,6 +29,7 @@ type Props = {
   setParticipants: (ps: Participant[]) => void
   setCurrentName: (s: string) => void
   setCurrentGrade: (s: string) => void
+  setCurrentComment: (s: string) => void
   setCurrentSchedule: (s: Participant['schedule']) => void
   setEditingIndex: (i: number | null) => void
   setActiveTab: (t: string) => void
@@ -45,6 +46,7 @@ export default function ParticipantList({
   setParticipants,
   setCurrentName,
   setCurrentGrade,
+  setCurrentComment,
   setCurrentSchedule,
   setEditingIndex,
   setActiveTab,
@@ -95,6 +97,7 @@ export default function ParticipantList({
     const origIdx = participants.findIndex((p) => p.id === part.id)
     setCurrentName(part.name)
     setCurrentGrade(part.grade)
+    setCurrentComment(part.comment ?? '')
     setCurrentSchedule(part.schedule)
     setEditingIndex(origIdx)
     setActiveTab('input')
@@ -208,6 +211,9 @@ export default function ParticipantList({
                 <th className="border p-1 sticky left-0 bg-white z-20">
                   {isEnglish ? 'Name' : '名前'}
                 </th>
+                <th className="border p-1 text-left align-top min-w-[160px]">
+                  {isEnglish ? 'Comment' : 'コメント'}
+                </th>
                 {xAxis.map((day) =>
                   yAxis.map((period) => (
                     <th
@@ -223,6 +229,7 @@ export default function ParticipantList({
                 <th className="border p-1 text-center sticky left-0 bg-gray-50 z-20">
                   {isEnglish ? 'Available Participants' : '参加可能者数'}
                 </th>
+                <th className="border p-1 text-center">-</th>
                 {xAxis.map((day) =>
                   yAxis.map((period) => (
                     <th
@@ -243,6 +250,13 @@ export default function ParticipantList({
                     onClick={() => handleEdit(idx)}
                   >
                     {part.grade}: {part.name}
+                  </td>
+                  <td className="border p-1 align-top text-sm whitespace-pre-wrap text-left text-muted-foreground">
+                    {part.comment && part.comment.trim() !== '' ? (
+                      part.comment
+                    ) : (
+                      <span className="text-gray-300">-</span>
+                    )}
                   </td>
                   {xAxis.map((day) =>
                     yAxis.map((period) => {
@@ -290,6 +304,11 @@ export default function ParticipantList({
                     </Button>
                   </div>
                 </div>
+                {part.comment && part.comment.trim() !== '' && (
+                  <CardDescription className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                    {part.comment}
+                  </CardDescription>
+                )}
               </CardHeader>
               <CardContent className="pt-0">
                 {isMobile ? (

--- a/app/events/[eventId]/components/ScheduleForm.tsx
+++ b/app/events/[eventId]/components/ScheduleForm.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import { MousePointer, Smartphone, Check } from "lucide-react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { toast } from "@/components/ui/use-toast"
@@ -28,6 +29,8 @@ type Props = {
   setCurrentName: Dispatch<SetStateAction<string>>
   currentGrade: string
   setCurrentGrade: Dispatch<SetStateAction<string>>
+  currentComment: string
+  setCurrentComment: Dispatch<SetStateAction<string>>
   currentSchedule: Schedule
   setCurrentSchedule: Dispatch<SetStateAction<Schedule>>
   participants: Participant[]
@@ -48,6 +51,8 @@ export default function ScheduleForm({
   setCurrentName,
   currentGrade,
   setCurrentGrade,
+  currentComment,
+  setCurrentComment,
   currentSchedule,
   setCurrentSchedule,
   participants,
@@ -151,12 +156,16 @@ export default function ScheduleForm({
     }
     setScheduleError("")
 
+    const scheduleData = { ...currentSchedule }
+    const trimmedComment = currentComment.trim()
+    const commentValue = trimmedComment === "" ? "" : trimmedComment
     const payload = {
       eventId,
       name: currentName,
       grade: currentGrade,
       gradePriority: gradeOrder[currentGrade],
-      schedule: currentSchedule,
+      schedule: scheduleData,
+      comment: commentValue,
     }
 
     try {
@@ -169,7 +178,13 @@ export default function ScheduleForm({
         })
         if (!res.ok) throw new Error()
         const updated = [...participants]
-        updated[editingIndex] = { id, ...payload }
+        updated[editingIndex] = {
+          id,
+          name: currentName,
+          grade: currentGrade,
+          schedule: scheduleData,
+          comment: commentValue,
+        }
         setParticipants(updated)
         setEditingIndex(null)
       } else {
@@ -179,7 +194,16 @@ export default function ScheduleForm({
           body: JSON.stringify(payload),
         })
         const { id } = await res.json()
-        setParticipants([...participants, { id, ...payload }])
+        setParticipants([
+          ...participants,
+          {
+            id,
+            name: currentName,
+            grade: currentGrade,
+            schedule: scheduleData,
+            comment: commentValue,
+          },
+        ])
       }
 
       toast({
@@ -188,6 +212,7 @@ export default function ScheduleForm({
       })
       setCurrentName("")
       setCurrentGrade("")
+      setCurrentComment("")
       setCurrentSchedule(createEmptySchedule(xAxis, yAxis, defaultTypeId))
       setSelectedCells({})
       setBulkScheduleType(defaultTypeId)
@@ -306,6 +331,21 @@ export default function ScheduleForm({
             </Select>
             {gradeError && <p className="mt-2 text-sm text-red-500">{gradeError}</p>}
           </div>
+        </div>
+
+        <div className="mb-4">
+          <Label htmlFor="comment">{isEnglish ? "Comment" : "コメント"}</Label>
+          <Textarea
+            id="comment"
+            value={currentComment}
+            onChange={(e) => setCurrentComment(e.target.value)}
+            placeholder={
+              isEnglish
+                ? "Add an optional comment"
+                : "補足があれば入力してください（任意）"
+            }
+            rows={3}
+          />
         </div>
 
         {/* 一括入力 */}

--- a/app/events/[eventId]/components/ScheduleForm.tsx
+++ b/app/events/[eventId]/components/ScheduleForm.tsx
@@ -86,8 +86,10 @@ export default function ScheduleForm({
       setCurrentName(p.name)
       setCurrentGrade(p.grade || "")
       setCurrentSchedule({ ...p.schedule })
+      setCurrentComment(p.comment ?? "")
     } else {
       setCurrentSchedule(createEmptySchedule(xAxis, yAxis, defaultTypeId))
+      setCurrentComment("")
     }
   }, [editingIndex, participants, xAxis, yAxis, defaultTypeId])
 

--- a/app/events/[eventId]/components/SchedulePage.tsx
+++ b/app/events/[eventId]/components/SchedulePage.tsx
@@ -44,6 +44,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions
   const [activeTab, setActiveTab] = useState('input')
   const [currentName, setCurrentName] = useState('')
   const [currentGrade, setCurrentGrade] = useState('')
+  const [currentComment, setCurrentComment] = useState('')
   const [currentSchedule, setCurrentSchedule] = useState<Schedule>(
     () => createEmptySchedule(xAxis, yAxis, defaultTypeId)
   )
@@ -79,7 +80,12 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions
       .then((res) => res.json())
       .then((data) => {
         if (Array.isArray(data.participants)) {
-          setParticipants(data.participants)
+          setParticipants(
+            data.participants.map((p: any) => ({
+              ...p,
+              comment: typeof p?.comment === 'string' ? p.comment.trim() : '',
+            }))
+          )
         }
       })
       .catch((e) => {
@@ -99,8 +105,10 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions
       setCurrentName(p.name)
       setCurrentGrade(p.grade || '')
       setCurrentSchedule({ ...p.schedule })
+      setCurrentComment(p.comment ?? '')
     } else {
       setCurrentSchedule(createEmptySchedule(xAxis, yAxis, defaultTypeId))
+      setCurrentComment('')
     }
   }, [editingIndex, participants, xAxis, yAxis, defaultTypeId])
 
@@ -117,7 +125,12 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions
       try {
         const data = JSON.parse(e.target?.result as string)
         if (Array.isArray(data)) {
-          setParticipants(data)
+          setParticipants(
+            data.map((item: any) => ({
+              ...item,
+              comment: typeof item?.comment === 'string' ? item.comment.trim() : '',
+            }))
+          )
           toast({
             title: isEnglish ? 'Import complete' : 'インポート完了',
             description: isEnglish
@@ -227,6 +240,8 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions
             setCurrentName={setCurrentName}
             currentGrade={currentGrade}
             setCurrentGrade={setCurrentGrade}
+            currentComment={currentComment}
+            setCurrentComment={setCurrentComment}
             currentSchedule={currentSchedule}
             setCurrentSchedule={setCurrentSchedule}
             participants={participants}
@@ -243,6 +258,7 @@ export default function SchedulePage({ xAxis, yAxis, scheduleTypes, gradeOptions
             setParticipants={setParticipants}
             setCurrentName={setCurrentName}
             setCurrentGrade={setCurrentGrade}
+            setCurrentComment={setCurrentComment}
             setCurrentSchedule={setCurrentSchedule}
             setEditingIndex={setEditingIndex}
             setActiveTab={setActiveTab}

--- a/app/events/[eventId]/components/constants.ts
+++ b/app/events/[eventId]/components/constants.ts
@@ -9,10 +9,10 @@ export type Response = {
   id: string
   name: string
   grade?: string
+  comment?: string
   schedule: {
     dateTime: string
     typeId: string
-    comment?: string
   }[]
 }
 

--- a/app/events/[eventId]/components/types.ts
+++ b/app/events/[eventId]/components/types.ts
@@ -1,13 +1,14 @@
 // 1人分のスケジュール（曜日-時限のキーに対して予定の値を持つ）
 export type Schedule = {
-    [key: string]: string
-  }
-  
-  // 参加者のデータ構造
-  export type Participant = {
-    id: string
-    name: string
-    grade: string 
-    schedule: Schedule
-  }
+  [key: string]: string
+}
+
+// 参加者のデータ構造
+export type Participant = {
+  id: string
+  name: string
+  grade: string
+  schedule: Schedule
+  comment?: string
+}
   


### PR DESCRIPTION
## Summary
- allow recurring event respondents to add an optional overall comment when entering their schedule
- store the submitted comment in the participants API so it appears in the response status view
- surface saved comments in the grid/list views and preload them when editing existing responses

## Testing
- pnpm lint *(fails: Next cannot resolve `styled-jsx` even after installation attempt)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1f7d0e048328968698d66e1ebcb6