### PR TITLE
Secure event API with access tokens and protect cron endpoint

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -27,6 +27,10 @@ Administrators manage resources and user permissions, approve reservations, and 
 - Node.js 18 or later
 - Yarn
 
+## Environment variables
+- `EVENT_PASSWORD_SECRET` (16+ characters): used to sign access tokens for password-protected events.
+- `CRON_SECRET_TOKEN`: requests to `/api/cron/delete-old-events` must include an `Authorization: Bearer <token>` header or a `?token=<token>` query parameter matching this value.
+
 ## Setup
 ```bash
 yarn install

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 - Node.js 18 以上
 - Yarn
 
+## 環境変数
+- `EVENT_PASSWORD_SECRET` (16文字以上): パスワード付きイベント向けアクセストークンの署名に使用します。
+- `CRON_SECRET_TOKEN`: `/api/cron/delete-old-events` を実行するリクエストは `Authorization: Bearer <このトークン>` ヘッダー、もしくは `?token=<このトークン>` のクエリパラメータを必ず付与してください。
+
 ## セットアップ
 ```bash
 yarn install

--- a/app/api/cron/delete-old-events/route.ts
+++ b/app/api/cron/delete-old-events/route.ts
@@ -1,10 +1,42 @@
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/lib/firebase"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
-export async function GET() {
+function authorizeCron(req: NextRequest) {
+  const secret = process.env.CRON_SECRET_TOKEN
+  if (!secret) {
+    console.error("CRON_SECRET_TOKEN is not configured")
+    return {
+      ok: false as const,
+      status: 500 as const,
+      body: { error: "cron secret not configured" },
+    }
+  }
+
+  const header = req.headers.get("authorization")
+  if (header && header.toLowerCase().startsWith("bearer ")) {
+    const token = header.slice(7).trim()
+    if (token === secret) {
+      return { ok: true as const }
+    }
+  }
+
+  const urlToken = new URL(req.url).searchParams.get("token")
+  if (urlToken && urlToken === secret) {
+    return { ok: true as const }
+  }
+
+  return { ok: false as const, status: 401 as const, body: { error: "unauthorized" } }
+}
+
+export async function GET(req: NextRequest) {
+  const auth = authorizeCron(req)
+  if (!auth.ok) {
+    return NextResponse.json(auth.body, { status: auth.status })
+  }
+
   try {
     const cutoff = new Date()
     cutoff.setMonth(cutoff.getMonth() - 3)

--- a/app/events/[eventId]/components/OneTimeInput.tsx
+++ b/app/events/[eventId]/components/OneTimeInput.tsx
@@ -20,6 +20,7 @@ import {
 
 type Props = {
   eventId: string
+  accessToken?: string | null
   dateTimeOptions: string[]
   scheduleTypes: ScheduleType[]
   existingResponses: Response[]
@@ -32,6 +33,7 @@ type Props = {
 
 export default function OneTimeInputTab({
   eventId,
+  accessToken,
   dateTimeOptions,
   scheduleTypes,
   existingResponses = [],
@@ -97,15 +99,20 @@ export default function OneTimeInputTab({
       }
 
       // APIエンドポイントに送信（実際の実装に合わせて調整）      
+      const headers: HeadersInit = {
+        "Content-Type": "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      }
       const response = await fetch(`/api/events/${eventId}/participants`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify(responseData),
       })
 
       if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error("認証が必要です")
+        }
         throw new Error("回答の送信に失敗しました")
       }
 

--- a/app/events/[eventId]/components/OneTimePage.tsx
+++ b/app/events/[eventId]/components/OneTimePage.tsx
@@ -41,6 +41,7 @@ import OneTimeSummaryTab from "./OneTimeSummary"
 
 type Props = {
   eventId: string
+  accessToken?: string | null
   dateTimeOptions: string[]
   scheduleTypes: ScheduleType[]
   responses?: Response[]
@@ -48,7 +49,7 @@ type Props = {
   gradeOrder: { [key: string]: number }
 }
 
-export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, responses = [], gradeOptions, gradeOrder }: Props) {
+export default function OneTimePage({ eventId, accessToken, dateTimeOptions, scheduleTypes, responses = [], gradeOptions, gradeOrder }: Props) {
   const [activeTab, setActiveTab] = useState("input")
   const [gradeOptionsState, setGradeOptionsState] = useState<string[]>(gradeOptions)
   const [gradeOrderState, setGradeOrderState] = useState<Record<string, number>>(gradeOrder)
@@ -67,7 +68,7 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
       return updated
     })
   }
-  const form = useParticipantForm(eventId, dateTimeOptions, scheduleTypes, responses, setActiveTab, gradeOptionsState, gradeOrderState)
+  const form = useParticipantForm(eventId, accessToken, dateTimeOptions, scheduleTypes, responses, setActiveTab, gradeOptionsState, gradeOrderState)
   const isMobile = useMediaQuery("(max-width: 768px)")      
 
   // 最適な日時を取得
@@ -94,6 +95,7 @@ export default function OneTimePage({ eventId, dateTimeOptions, scheduleTypes, r
         {/* 入力タブ */}
         <OneTimeInputTab
             eventId={eventId}
+            accessToken={accessToken}
             dateTimeOptions={dateTimeOptions}
             scheduleTypes={scheduleTypes}
             existingResponses={form.existingResponses}

--- a/lib/event-auth.ts
+++ b/lib/event-auth.ts
@@ -1,0 +1,65 @@
+import crypto from "crypto"
+import type { NextRequest } from "next/server"
+
+function getEventSecret(): string {
+  const secret = process.env.EVENT_PASSWORD_SECRET
+  if (!secret || secret.length < 16) {
+    throw new Error("EVENT_PASSWORD_SECRET is not configured or too short")
+  }
+  return secret
+}
+
+export function createEventAccessToken(eventId: string, password: string): string {
+  const secret = getEventSecret()
+  const hmac = crypto.createHmac("sha256", secret)
+  hmac.update(`${eventId}:${password}`)
+  return hmac.digest("hex")
+}
+
+export function verifyEventAccessToken(
+  token: string | null | undefined,
+  eventId: string,
+  password: string | undefined,
+): boolean {
+  if (!password) return true
+  if (!token) return false
+
+  try {
+    const expected = createEventAccessToken(eventId, password)
+    const expectedBuffer = Buffer.from(expected, "hex")
+    const providedBuffer = Buffer.from(token, "hex")
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false
+    }
+    return crypto.timingSafeEqual(expectedBuffer, providedBuffer)
+  } catch (err) {
+    console.error("Failed to verify event access token", err)
+    return false
+  }
+}
+
+export function extractEventAccessToken(req: NextRequest): string | null {
+  const headerToken = req.headers.get("x-event-token")
+  if (headerToken && headerToken.trim()) {
+    return headerToken.trim()
+  }
+
+  const authorization = req.headers.get("authorization")
+  if (authorization) {
+    const match = authorization.match(/^Bearer\s+(.+)$/i)
+    if (match) {
+      return match[1].trim()
+    }
+  }
+
+  return null
+}
+
+export function passwordsMatch(candidate: string, actual: string): boolean {
+  const candidateBuffer = Buffer.from(candidate)
+  const actualBuffer = Buffer.from(actual)
+  if (candidateBuffer.length !== actualBuffer.length) {
+    return false
+  }
+  return crypto.timingSafeEqual(candidateBuffer, actualBuffer)
+}


### PR DESCRIPTION
## Summary
- add server-side helpers to sign and validate event access tokens and require them for event updates and participant APIs
- update the event UI to persist access tokens, send them with participant requests, and surface authentication errors across schedule and one-time views
- lock down the cron deletion endpoint with a shared secret and document the new environment variables

## Testing
- pnpm lint *(fails: next binary not installed because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6c148f448328a0b7d536e9b98839